### PR TITLE
LogEntry: Simplify LogEntry and redefign logging.

### DIFF
--- a/examples/standard/main.cpp
+++ b/examples/standard/main.cpp
@@ -18,14 +18,14 @@ int main(){
 
 	{
 		Logging::Logger logger = Logging::Logger(config);
-		logger << Logging::LogLevel::Info << "This" << " is" << " a" << " test.";
-		logger << Logging::LogLevel::Debug << "Debug" << " Entry";
-		logger << Logging::LogLevel::Error << "Error text";
+		logger.Log(Logging::LogLevel::Info, "This is a test.");
+		logger.Log(Logging::LogLevel::Debug, "Debug Entry");
+		logger.Log(Logging::LogLevel::Error, "Error text");
 	}
 
 	std::cout << "\nMockData:\n";
 	for (const auto& entry : mock->m_logEntries){
-		std::cout << LevelToText(entry.GetLevel()) + " " + entry.GetText() + "\n";
+		std::cout << LevelToText(entry.m_level) + " " + entry.m_text + "\n";
 	}
 
 	// Cleanup log file

--- a/src/LogEntry.cpp
+++ b/src/LogEntry.cpp
@@ -1,39 +1,9 @@
 #include "LogEntry.hpp"
 
-#include <chrono>
-#include <sstream>
-#include <iomanip>
-
 namespace Logging {
-
-LogEntry::LogEntry(LogLevel level) : m_level(level)
-{
-    const auto timeNow = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-
-    std::stringstream ss;
-    ss << std::put_time(std::localtime(&timeNow), "%d.%m.%Y %H:%M:%S");
-    m_time = ss.str();
-}
-
-LogEntry& LogEntry::operator<<(const std::string& text) {
-    m_text += text;
-    return *this;
-}
 
 std::string LogEntry::OutputText() const {
     return m_time + " " + LevelToText(m_level) + " " + m_text;  
-}
-
-std::string LogEntry::GetText() const {
-    return m_text;
-}
-
-std::string LogEntry::GetTime() const {
-    return m_time;
-}
-
-LogLevel LogEntry::GetLevel() const {
-    return m_level;
 }
 
 }

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -1,5 +1,9 @@
 #include "Logger.hpp"
 
+#include <chrono>
+#include <sstream>
+#include <iomanip>
+
 namespace Logging {
 
 Logger::Logger(LogConfig& config) : m_config(config)
@@ -11,9 +15,14 @@ Logger::~Logger() {
     }
 }
 
-LogEntry& Logger::operator<<(LogLevel level) {
-    m_entries.emplace_back(LogEntry(level));
-    return m_entries.back();
+void Logger::Log(const LogLevel level, const std::string& text) {
+    // Get current time
+    const auto timeNow = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    std::stringstream time;
+    time << std::put_time(std::localtime(&timeNow), "%d.%m.%Y %H:%M:%S");
+
+    LogEntry entry{level, text, time.str()};
+    m_entries.emplace_back(entry);
 }
 
 }

--- a/src/include/LogEntry.hpp
+++ b/src/include/LogEntry.hpp
@@ -7,29 +7,13 @@
 
 namespace Logging {
 
-class LogEntry{
-public:
-	LogEntry(LogLevel level);
-
-    //! Log new text.
-	LogEntry& operator<<(const std::string& text);
-
-	//! Returns the logged text formatted with the log level.
+struct LogEntry {
+	//! Returns the formatted log entry data.
 	std::string OutputText() const;
 
-    //! Returns the logged text.
-	std::string GetText() const;
-
-	//! Returns the timeStamp of the log entry.
-	std::string GetTime() const;
-	
-	//! Returns the log level of the entry.
-	LogLevel GetLevel() const;
-
-private:
 	LogLevel m_level;   //!< Log level of this one entry.
-	std::string m_time; //!< Timestamp of the log entry.
 	std::string m_text; //!< All log entries.
+	std::string m_time; //!< Timestamp of the log entry.
 };
 
 }

--- a/src/include/Logger.hpp
+++ b/src/include/Logger.hpp
@@ -18,7 +18,7 @@ public:
 	// TODO: Allow intermediate output -> WriteLogEntries function; also clears the m_entries.
 
 	//! Add a new log entry with the specified log level.
-	LogEntry& operator<<(LogLevel level);
+	void Log(LogLevel level, const std::string& text);
 
 private:
 	LogConfig& m_config;              //!< Configuration by which this logger object should adhere.

--- a/tests/LogEntry.gtest.cpp
+++ b/tests/LogEntry.gtest.cpp
@@ -7,11 +7,10 @@ namespace Logging {
 namespace GTest {
 
 TEST(LogEntry, OutputFormat) {
-    LogEntry logEntry(LogLevel::Info);
-    logEntry << "This is a " << "test";
-    const std::string expected = "[Info] This is a test";
+    LogEntry logEntry{LogLevel::Info, "This is a test", "2023-02-03 15:47:00"};
+    const std::string expected = "2023-02-03 15:47:00 [Info] This is a test";
 
-    EXPECT_TRUE(logEntry.OutputText().find(expected) != std::string::npos);
+    EXPECT_STREQ(logEntry.OutputText().c_str(), expected.c_str());
 
 /*
     std::regex r("%d%d.%d%d.%d%d %d%d-%d%d-%d%d%d%d [%s] %s");

--- a/tests/LogOutput.gtest.cpp
+++ b/tests/LogOutput.gtest.cpp
@@ -19,21 +19,21 @@ TEST(LogOutput, Mock) {
 
 	{
 		Logger logger = Logger(config);
-		logger << LogLevel::Info << "This" << " is" << " a" << " test.";
-		logger << LogLevel::Debug << "Debug" << " Entry";
-		logger << LogLevel::Error << "Error text";
+		logger.Log(LogLevel::Info, "This is a test.");
+		logger.Log(LogLevel::Debug, "Debug Entry");
+		logger.Log(LogLevel::Error, "Error text");
 	}
 
     EXPECT_EQ(mock->m_logEntries.size(), 3);
     
-	EXPECT_STREQ(mock->m_logEntries[0].GetText().c_str(), "This is a test.");
-	EXPECT_EQ(mock->m_logEntries[0].GetLevel(), LogLevel::Info);
+	EXPECT_STREQ(mock->m_logEntries[0].m_text.c_str(), "This is a test.");
+	EXPECT_EQ(mock->m_logEntries[0].m_level, LogLevel::Info);
 
-    EXPECT_STREQ(mock->m_logEntries[1].GetText().c_str(), "Debug Entry");
-	EXPECT_EQ(mock->m_logEntries[1].GetLevel(), LogLevel::Debug);
+    EXPECT_STREQ(mock->m_logEntries[1].m_text.c_str(), "Debug Entry");
+	EXPECT_EQ(mock->m_logEntries[1].m_level, LogLevel::Debug);
 
-    EXPECT_STREQ(mock->m_logEntries[2].GetText().c_str(), "Error text");
-	EXPECT_EQ(mock->m_logEntries[2].GetLevel(), LogLevel::Error);
+    EXPECT_STREQ(mock->m_logEntries[2].m_text.c_str(), "Error text");
+	EXPECT_EQ(mock->m_logEntries[2].m_level, LogLevel::Error);
 }
 
 TEST(LogOutput, FileBasic) {
@@ -67,9 +67,9 @@ TEST(LogOutput, FileBasic) {
 	// Write data to file
 	{
 		Logger logger = Logger(config);
-		logger << LogLevel::Info << "This" << " is" << " a" << " test.";
-		logger << LogLevel::Debug << "Debug" << " Entry";
-		logger << LogLevel::Error << "Error text";
+		logger.Log(LogLevel::Info,"This is a test.");
+		logger.Log(LogLevel::Debug, "Debug Entry");
+		logger.Log(LogLevel::Error, "Error text");
 	}
 
 	// Check the file content is as expected
@@ -93,7 +93,7 @@ TEST(LogOutput, FileMaxSize) {
 
 	// Write to output file
 	{
-		Logger(config) << LogLevel::Info << testString;
+		Logger(config).Log(LogLevel::Info, testString);
 	}
 	EXPECT_FALSE(std::filesystem::exists("Logfile.txt"));    // New file only created after next write
 	EXPECT_TRUE(std::filesystem::exists("Logfile(1).txt"));  // Wrapping happens after a write
@@ -101,7 +101,7 @@ TEST(LogOutput, FileMaxSize) {
 
 	// Less than maxSize Bytes
 	{
-		Logger(config) << LogLevel::Info << "a";	
+		Logger(config).Log(LogLevel::Info, "a");
 	}
 	EXPECT_TRUE(std::filesystem::exists("Logfile.txt"));     // New write -> Create file again
 	EXPECT_TRUE(std::filesystem::exists("Logfile(1).txt"));  // Still exists
@@ -109,7 +109,7 @@ TEST(LogOutput, FileMaxSize) {
 
 	// Fill the current log file
 	{
-		Logger(config) << LogLevel::Debug << testString;
+		Logger(config).Log(LogLevel::Debug, testString);
 	}
 	EXPECT_FALSE(std::filesystem::exists("Logfile.txt"));    // New file only created after new write
 	EXPECT_TRUE(std::filesystem::exists("Logfile(1).txt"));  // Still exists
@@ -119,8 +119,8 @@ TEST(LogOutput, FileMaxSize) {
 	// Fill two files worth (whole will be in one file -> One write operation)
 	{
 		Logger logger = Logger(config);
-		logger << LogLevel::Debug << testString;
-		logger << LogLevel::Debug << testString;
+		logger.Log(LogLevel::Debug, testString);
+		logger.Log(LogLevel::Debug, testString);
 	}
 	EXPECT_FALSE(std::filesystem::exists("Logfile.txt"));    // New file only created after new write
 	EXPECT_TRUE(std::filesystem::exists("Logfile(1).txt"));  // Still exists


### PR DESCRIPTION
Redesign logging so we don't use the << operator but rather just a function for logging.
This reduces the complexity and honestly.. it's just nicer.

Protip: Use the fmt library if you are currently using stringstreams for formatting..
**Changes**
 - LogEntry: Is now just a struct
 - Logger: Now uses Log() function instead of << operator for new entries
 - Updated unit tests and examples